### PR TITLE
Fix subscriptions with frozen arguments causing subscription cycles

### DIFF
--- a/src/ferp/freeze.js
+++ b/src/ferp/freeze.js
@@ -1,4 +1,6 @@
-export const freeze = (value) => {
+import { pure } from './util/pure.js';
+
+export const freeze = pure((value) => {
   if (typeof value !== 'object' || value === null) {
     return value;
   }
@@ -7,4 +9,4 @@ export const freeze = (value) => {
     get: (target, property) => freeze(target[property]),
     deleteProperty: () => false,
   });
-};
+});

--- a/src/ferp/subscriptionManager.js
+++ b/src/ferp/subscriptionManager.js
@@ -52,7 +52,7 @@ export const subscriptionManager = (dispatch, subscribe) => {
   const next = (state) => {
     store = subscriptionUpdate(
       store,
-      subscribe(state),
+      subscribe(freeze(state)),
       dispatch,
     );
   };

--- a/src/ferp/subscriptionManager.js
+++ b/src/ferp/subscriptionManager.js
@@ -52,7 +52,7 @@ export const subscriptionManager = (dispatch, subscribe) => {
   const next = (state) => {
     store = subscriptionUpdate(
       store,
-      subscribe(freeze(state)),
+      subscribe(state),
       dispatch,
     );
   };


### PR DESCRIPTION
The state was being frozen per update cycle, and that was creating a new proxy each time. This caused subscriptions that used state values to be retriggered every update.

I'm not sure this is the correct fix. This could be a pure function, which would also resolve the issue. Just not sure that it's worth freezing. I like the idea of keeping the user from accidentally mutating the state, but it is an extra function call, even as a pure function.

I need to evaluate if the implied contract of ferp to a developer covers immutability, or if the developer can't be trusted.