### PR TITLE
Fix expectation checking bug

### DIFF
--- a/docs/tester/reference.md
+++ b/docs/tester/reference.md
@@ -63,6 +63,11 @@ If all expectations were met, this will return `true`, otherwise it will return 
 
 This returns an array of failed expectations, in the form of `[{ type: effectType, annotation: '' }, ...]`.
 
+#### `t.missed()`
+
+This returns an array of missed expectations, in the form of `[{ type: effectType, annotation: '' }, ...]`.
+These can be ignored, but may hint at further expecations you can add to your test.
+
 #### `t.state()`
 
 If an initial state was set in the exported `tester()` function, `state()` will return a copy of state with any modifications ran by any actions during the test.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "ferp.esm.js",
   "main": "ferp.min.js",
   "description": "Build functional and pure applications in NodeJS and the Browser!",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ferp-js/ferp.git"

--- a/src/testing/example.test.js
+++ b/src/testing/example.test.js
@@ -62,7 +62,6 @@ test('will batch actions', async (t) => {
     .willBatch('multi')
     .willAct('action1')
     .willAct('action2')
-    .willAct('action3')
     .fromEffect(effects.batch([
       effects.act(action1),
       effects.act(action2),
@@ -70,6 +69,10 @@ test('will batch actions', async (t) => {
     ], 'multi'));
 
   t.truthy(tester.ok());
+
+  t.deepEqual(tester.missed(), [
+    { type: 'Symbol(act)', annotation: 'action3' },
+  ]);
 });
 
 test('can test a subscription', (t) => {


### PR DESCRIPTION
 - If expectation not found, don't remove any expectations
 - Add `tester.missed()`, which returns an array of expectations you could add to your test